### PR TITLE
Add top committers view and fix review comment totals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@ dist
 
 client/node_modules
 client/dist
+client/tsconfig.tsbuildinfo
 client/.env
 server/node_modules
 server/dist
+server/tsconfig.tsbuildinfo
 server/.env

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import RepoPicker from './components/RepoPicker'
 import PRList from './components/PRList'
 import ReviewersView from './components/ReviewersView'
 import ReviewersSidebar from './components/ReviewersSidebar'
+import CommittersView from './components/CommittersView'
 import { loadSettings, saveSettings } from './store'
 import { useQuery } from '@tanstack/react-query'
 import { fetchTeams } from './api'
@@ -13,7 +14,7 @@ export default function App() {
   const [username, setUsername] = useState(loadSettings().username)
   const [favorites, setFavorites] = useState<string[]>(loadSettings().favorites)
   const [refreshMs, setRefreshMs] = useState(loadSettings().refreshMs)
-  const [tab, setTab] = useState<'prs'|'reviewers'>('prs')
+  const [tab, setTab] = useState<'prs'|'reviewers'|'committers'>('prs')
   const [reviewWindow, setReviewWindow] = useState<'24h'|'7d'|'30d'>('24h')
   const [selectedUsers, setSelectedUsers] = useState<string[]>([])
   const [selectedTeams, setSelectedTeams] = useState<string[]>([])
@@ -58,6 +59,7 @@ export default function App() {
         <div className="inline-flex rounded-full border border-zinc-700 overflow-hidden">
           <button onClick={() => setTab('prs')} className={`px-3 py-1 text-sm ${tab==='prs' ? 'bg-brand-500/20' : ''}`}>PRs</button>
           <button onClick={() => setTab('reviewers')} className={`px-3 py-1 text-sm ${tab==='reviewers' ? 'bg-brand-500/20' : ''}`}>Reviewers</button>
+          <button onClick={() => setTab('committers')} className={`px-3 py-1 text-sm ${tab==='committers' ? 'bg-brand-500/20' : ''}`}>Committers</button>
         </div>
       </header>
       <section className="grid md:grid-cols-3 gap-6">
@@ -115,10 +117,14 @@ export default function App() {
             canShowPRs
               ? <PRList org={org} repos={favorites} username={username} refreshMs={refreshMs} windowSel={reviewWindow} onChangeSelected={setReviewWindow} />
               : <div className="text-sm text-zinc-400">Select at least one favorite repository to see PRs.</div>
-          ) : (
+          ) : tab === 'reviewers' ? (
             org
               ? <ReviewersView org={org} favorites={favorites} selectedUsers={selectedUsersEffective} windowSel={reviewWindow} onChangeSelected={setReviewWindow}/>
               : <div className="text-sm text-zinc-400">Enter an organization to see reviewers.</div>
+          ) : (
+            canShowPRs
+              ? <CommittersView org={org} favorites={favorites} windowSel={reviewWindow} onChangeWindow={setReviewWindow} />
+              : <div className="text-sm text-zinc-400">Select at least one favorite repository to see committers.</div>
           )}
         </div>
       </section>

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import type { Repo, PREnriched, ReviewerStat, OrgTeam } from './types'
+import type { Repo, PREnriched, ReviewerStat, CommitterStat, OrgTeam } from './types'
 
 export async function fetchRepos(org: string): Promise<Repo[]> {
   const { data } = await axios.get<{ repos: Repo[] }>(`/api/orgs/${encodeURIComponent(org)}/repos`)
@@ -17,6 +17,15 @@ export async function fetchTopReviewers(
   window: '24h' | '7d' | '30d'
 ): Promise<{ since: string; reviewers: ReviewerStat[] }> {
   const { data } = await axios.post(`/api/reviewers/top`, { org, repos, window })
+  return data
+}
+
+export async function fetchTopCommitters(
+  org: string,
+  repos: string[],
+  window: '24h' | '7d' | '30d'
+): Promise<{ since: string; committers: CommitterStat[] }> {
+  const { data } = await axios.post(`/api/committers/top`, { org, repos, window })
   return data
 }
 

--- a/client/src/components/CommittersView.tsx
+++ b/client/src/components/CommittersView.tsx
@@ -1,0 +1,115 @@
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { fetchTopCommitters } from '../api'
+import type { CommitterStat } from '../types'
+import { ageClass, fromNow, short } from '../lib_time'
+
+type Props = {
+  org: string
+  favorites: string[]
+  windowSel: '24h'|'7d'|'30d'
+  onChangeWindow: (window: '24h'|'7d'|'30d') => void
+}
+
+export default function CommittersView({ org, favorites, windowSel, onChangeWindow }: Props) {
+  const { data, isFetching, refetch, isError, error } = useQuery({
+    queryKey: ['top-committers', org, windowSel, ...[...favorites].sort()],
+    queryFn: () => fetchTopCommitters(org, favorites, windowSel),
+    enabled: !!org && favorites.length > 0,
+    refetchOnWindowFocus: true,
+  })
+
+  const committers = (data?.committers ?? []) as CommitterStat[]
+  const sorted = useMemo(
+    () => [...committers].sort((a,b) => b.commits - a.commits || (b.lastCommitAt ?? '').localeCompare(a.lastCommitAt ?? '')),
+    [committers]
+  )
+
+  const since = data?.since
+
+  const medal = (i: number) => (i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : '')
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <div className="inline-flex rounded-full border border-zinc-700 overflow-hidden">
+          {(['24h','7d','30d'] as const).map(w => (
+            <button
+              key={w}
+              onClick={() => onChangeWindow(w)}
+              aria-pressed={windowSel === w}
+              className={`px-3 py-1 text-xs transition ${
+                windowSel === w ? 'bg-brand-500/20' : 'hover:bg-zinc-800'
+              }`}
+            >
+              {w}
+            </button>
+          ))}
+        </div>
+        <button
+          onClick={() => refetch()}
+          className="text-xs px-2 py-1 rounded-full border border-zinc-700 hover:bg-zinc-800 inline-flex items-center gap-2"
+        >
+          Refresh
+          {isFetching && (
+            <span className="inline-block w-3 h-3 border-2 border-zinc-500 border-t-transparent rounded-full animate-spin" />
+          )}
+        </button>
+      </div>
+
+      <div className="card p-4 overflow-x-auto">
+        {isError ? (
+          <div className="text-red-300">Error: {(error as Error).message}</div>
+        ) : sorted.length === 0 ? (
+          <div className="text-sm text-zinc-400">No commits in this window.</div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="text-zinc-400">
+              <tr className="text-left">
+                <th className="py-2">Committer</th>
+                <th className="py-2">Commits</th>
+                <th className="py-2">➕</th>
+                <th className="py-2">➖</th>
+                <th className="py-2">Repos</th>
+                <th className="py-2">Last commit</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((c, i) => (
+                <tr key={c.user + i} className="border-t border-zinc-800">
+                  <td className="py-2 font-medium">
+                    <span aria-hidden className="mr-1 text-[16px] leading-none align-middle">{medal(i)}</span>
+                    <a
+                      href={`https://github.com/${encodeURIComponent(c.user)}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-zinc-200 hover:opacity-90"
+                      title={`Open ${c.user} on GitHub`}
+                    >
+                      {c.user}
+                    </a>
+                    {c.displayName && (
+                      <div className="text-xs text-zinc-400">{c.displayName}</div>
+                    )}
+                  </td>
+                  <td className="py-2">{c.commits}</td>
+                  <td className="py-2">{c.additions}</td>
+                  <td className="py-2">{c.deletions}</td>
+                  <td className="py-2">{c.repos.length}</td>
+                  <td className="py-2">
+                    {c.lastCommitAt ? (
+                      <span className={ageClass(c.lastCommitAt)} title={short(c.lastCommitAt)}>
+                        {fromNow(c.lastCommitAt)}
+                      </span>
+                    ) : '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+        {since && <div className="mt-3 text-xs text-zinc-500">Since {short(since)}</div>}
+      </div>
+    </div>
+  )
+}

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -42,5 +42,15 @@ export type ReviewerStat = {
   repos: string[]
 }
 
+export type CommitterStat = {
+  user: string
+  displayName?: string | null
+  commits: number
+  additions: number
+  deletions: number
+  repos: string[]
+  lastCommitAt?: string | null
+}
+
 export type TeamMember = { login: string; name?: string | null }
 export type OrgTeam = { slug: string; name: string; members: TeamMember[] }

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -40,9 +40,20 @@ export interface ReviewerStat {
   total: number;
   approvals: number;
   changesRequested: number;
+  commented: number;
   comments: number;
   lastReviewAt?: string | null;
   repos: string[]; // distinct repos they reviewed in (nameWithOwner or full slug)
+}
+
+export interface CommitterStat {
+  user: string;
+  displayName?: string | null;
+  commits: number;
+  additions: number;
+  deletions: number;
+  repos: string[];
+  lastCommitAt?: string | null;
 }
 export interface TeamMember { login: string; name?: string | null }
 export interface OrgTeam { slug: string; name: string; members: TeamMember[] }

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
+    "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "outDir": "dist",
     "rootDir": "src",


### PR DESCRIPTION
## Summary
- add a GitHub GraphQL aggregation for top committers along with a client view and API endpoint to display the leaderboard
- fix reviewer stats deduplication so multi-comment reviews count once and ensure comment totals accumulate safely
- adjust shared types plus TypeScript config and gitignore so builds succeed without stray artifacts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d44c7adf408328a4c32a6a129be082