### PR TITLE
Send reviewer filters to backend

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -14,9 +14,21 @@ export async function fetchPRs(org: string, repos: string[], states: ('open'|'me
 export async function fetchTopReviewers(
   org: string,
   repos: string[],
-  window: '24h' | '7d' | '30d'
+  window: '24h' | '7d' | '30d',
+  users?: string[]
 ): Promise<{ since: string; reviewers: ReviewerStat[] }> {
-  const { data } = await axios.post(`/api/reviewers/top`, { org, repos, window })
+  const payload: {
+    org: string
+    repos: string[]
+    window: '24h' | '7d' | '30d'
+    users?: string[]
+  } = { org, repos, window }
+
+  if (users?.length) {
+    payload.users = users
+  }
+
+  const { data } = await axios.post(`/api/reviewers/top`, payload)
   return data
 }
 

--- a/client/src/components/ReviewersView.tsx
+++ b/client/src/components/ReviewersView.tsx
@@ -13,9 +13,12 @@ type Props = {
 }
 
 export default function ReviewersView({ org, favorites, windowSel, selectedUsers, onChangeSelected }: Props) {
+  const sortedFavorites = useMemo(() => [...favorites].sort((a, b) => a.localeCompare(b)), [favorites])
+  const sortedUsers = useMemo(() => [...selectedUsers].sort((a, b) => a.localeCompare(b)), [selectedUsers])
+
   const { data, isFetching, refetch, isError, error } = useQuery({
-    queryKey: ['top-reviewers', org, windowSel, ...[...favorites].sort()],
-    queryFn: () => fetchTopReviewers(org, favorites, windowSel),
+    queryKey: ['top-reviewers', org, windowSel, ...sortedFavorites, 'users', ...sortedUsers],
+    queryFn: () => fetchTopReviewers(org, favorites, windowSel, sortedUsers),
     enabled: !!org && favorites.length > 0,
     refetchOnWindowFocus: true,
   })

--- a/server/src/gh.ts
+++ b/server/src/gh.ts
@@ -204,11 +204,22 @@ async function runGraphQL(query: string, vars: Record<string,string|null|undefin
 export async function ghTopReviewers(
   org: string,
   repos: string[],
-  window: "24h" | "7d" | "30d"
+  window: "24h" | "7d" | "30d",
+  users?: string[] | null
 ): Promise<{ since: string; reviewers: ReviewerStat[] }> {
   const since = buildSinceISO(window);
   const REPO_BATCH = Number(process.env.REPO_BATCH ?? 6); // keep search queries short
   const SEARCH_PAGE_LIMIT = Number(process.env.SEARCH_PAGE_LIMIT ?? 5); // up to 500 PRs/batch
+
+  const sanitizedUsers = Array.from(
+    new Map(
+      (users ?? [])
+        .map(u => u?.trim())
+        .filter((u): u is string => !!u)
+        .map(u => [u.toLowerCase(), u] as const)
+    ).values()
+  );
+  const userFilterSet = sanitizedUsers.length ? new Set(sanitizedUsers.map(u => u.toLowerCase())) : null;
 
   // Build batches of repos to avoid query-length limits
   const repoBatches = batch(repos, REPO_BATCH);
@@ -269,8 +280,16 @@ export async function ghTopReviewers(
 
   for (const batchRepos of repoBatches) {
     // search string: org + date + repos
-    const repoQuals = batchRepos.map(r => `repo:${org}/${r}`).join(" ");
-    const qBase = `org:${org} is:pr updated:>=${since} ${repoQuals}`.trim();
+    const repoQuals = batchRepos.map(r => `repo:${org}/${r}`);
+    const userQuals = sanitizedUsers.map(u => `involves:${u}`);
+    const qParts = [
+      `org:${org}`,
+      "is:pr",
+      `updated:>=${since}`,
+      ...repoQuals,
+      ...userQuals,
+    ];
+    const qBase = qParts.join(" ").trim();
 
     let cursor: string | null = null;
     for (let page = 0; page < SEARCH_PAGE_LIMIT; page++) {
@@ -291,6 +310,7 @@ export async function ghTopReviewers(
           const when = r.submittedAt ?? r.updatedAt ?? null;
           if (!when || when < since) continue; // outside window
           const user = r.author?.login ?? "unknown";
+          if (userFilterSet && !userFilterSet.has(user.toLowerCase())) continue;
           const name = (r.author as any)?.name ?? null;
 
           if (!counts.has(user)) {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -51,14 +51,15 @@ app.post("/api/prs", async (req, res) => {
 const TopReviewersBody = z.object({
   org: z.string().min(1),
   repos: z.array(z.string().min(1)).min(1),
-  window: z.enum(['24h','7d','30d'])
+  window: z.enum(['24h','7d','30d']),
+  users: z.array(z.string().min(1)).optional(),
 });
 
 
 app.post("/api/reviewers/top", async (req, res) => {
   try {
     const body = TopReviewersBody.parse(req.body);
-    const data = await ghTopReviewers(body.org, body.repos, body.window);
+    const data = await ghTopReviewers(body.org, body.repos, body.window, body.users);
     res.json(data);
   } catch (e:any) {
     const msg = `${e?.stderr ?? ''} ${e?.message ?? ''}`;

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
+    "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "outDir": "dist",
     "rootDir": "src",


### PR DESCRIPTION
## Summary
- allow the client to pass optional reviewer filters when fetching top reviewers
- forward the filter list through the API and GraphQL search while sanitizing user logins
- update the server TypeScript config so the build succeeds with NodeNext module resolution

## Testing
- npm run build (client)
- npm run build (server)

------
https://chatgpt.com/codex/tasks/task_e_68d5208c945c8328b5fbcd61633887aa