### PR TITLE
feat: visualize reviewer stats with stacked bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist
 client/node_modules
 client/dist
 client/.env
+client/tsconfig.tsbuildinfo
 server/node_modules
 server/dist
 server/.env

--- a/client/src/components/ReviewBar.tsx
+++ b/client/src/components/ReviewBar.tsx
@@ -1,0 +1,59 @@
+import type { JSX } from 'react'
+
+export type ReviewBarProps = {
+  approvals: number
+  changesRequested: number
+  commented: number
+}
+
+export const ReviewBar = ({ approvals, changesRequested, commented }: ReviewBarProps): JSX.Element => {
+  const total = approvals + changesRequested + commented
+
+  const segments = [
+    { key: 'approvals', label: 'Approvals', value: approvals, color: 'bg-emerald-500' },
+    { key: 'changes', label: 'Changes requested', value: changesRequested, color: 'bg-rose-500' },
+    { key: 'comments', label: 'Comments', value: commented, color: 'bg-zinc-500' },
+  ]
+
+  if (!total) {
+    return (
+      <div className="h-5 w-full bg-zinc-800">
+        <span className="sr-only">No reviews yet</span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-5 w-full items-stretch bg-zinc-800">
+      {segments.map(segment => {
+        const percent = Math.round((segment.value / total) * 100)
+        const segmentClasses = [
+          segment.color,
+          'h-full w-full transition-[filter] duration-150 ease-out',
+          'group-hover:brightness-110 group-focus-visible:brightness-110',
+        ].join(' ')
+
+        const tooltipClasses = [
+          'pointer-events-none absolute bottom-full left-1/2 mb-2 -translate-x-1/2 translate-y-1',
+          'whitespace-nowrap rounded bg-zinc-900 px-2 py-1 text-xs text-zinc-100 opacity-0 shadow-lg transition',
+          'group-hover:translate-y-0 group-hover:opacity-100 group-focus-visible:translate-y-0 group-focus-visible:opacity-100',
+        ].join(' ')
+
+        return (
+          <div
+            key={segment.key}
+            className="relative group flex-1 outline-none"
+            style={{ flexGrow: Math.max(segment.value, 0.0001), flexBasis: 0 }}
+            tabIndex={0}
+            aria-label={`${segment.label}: ${segment.value} (${percent}%)`}
+          >
+            <div className={segmentClasses} />
+            <span className={tooltipClasses}>
+              {segment.label}: {segment.value} ({percent}%)
+            </span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/client/src/components/ReviewersView.tsx
+++ b/client/src/components/ReviewersView.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query'
 import { fetchTopReviewers } from '../api'
 import type { ReviewerStat } from '../types'
 import { fromNow, short, ageClass } from '../lib_time'
+import { ReviewBar } from './ReviewBar'
 
 type Props = {
   org: string
@@ -92,7 +93,7 @@ export default function ReviewersView({ org, windowSel, selectedUsers, onChangeS
                       href={`https://github.com/${encodeURIComponent(r.user)}`}
                       target="_blank"
                       rel="noreferrer"
-                      className="text-zinc-200 hover:opacity-90"   // no underline now
+                      className="text-zinc-200 hover:opacity-90"
                       title={`Open ${r.user} on GitHub`}
                     >
                       {r.user}
@@ -101,11 +102,11 @@ export default function ReviewersView({ org, windowSel, selectedUsers, onChangeS
                       <div className="text-xs text-zinc-400">{r.displayName}</div>
                     )}
                   </td>
-                  <td className="py-2">{r.total}</td>
-                  <td className="py-2">
+                  <td className="py-2 text-base font-semibold">{r.total}</td>
+                  <td className="py-2 pr-6">
                     <ReviewBar approvals={r.approvals} changesRequested={r.changesRequested} commented={r.commented} />
                   </td>
-                  <td className="py-2">{approvalPercent === null ? '—' : approvalPercent}</td>
+                  <td className="py-2 text-base font-semibold">{approvalPercent === null ? '—' : approvalPercent}</td>
                   <td className="py-2">
                     {r.lastReviewAt ? (
                       <span className={ageClass(r.lastReviewAt)} title={short(r.lastReviewAt)}>
@@ -121,64 +122,6 @@ export default function ReviewersView({ org, windowSel, selectedUsers, onChangeS
         )}
         {since && <div className="mt-3 text-xs text-zinc-500">Since {short(since)}</div>}
       </div>
-    </div>
-  )
-}
-
-type ReviewBarProps = {
-  approvals: number
-  changesRequested: number
-  commented: number
-}
-
-function ReviewBar({ approvals, changesRequested, commented }: ReviewBarProps) {
-  const total = approvals + changesRequested + commented
-
-  const segments = [
-    { key: 'approvals', label: 'Approvals', value: approvals, color: 'bg-emerald-500' },
-    { key: 'changes', label: 'Changes requested', value: changesRequested, color: 'bg-rose-500' },
-    { key: 'comments', label: 'Comments', value: commented, color: 'bg-zinc-500' },
-  ]
-
-  if (!total) {
-    return (
-      <div className="h-4 w-full rounded-full bg-zinc-800">
-        <span className="sr-only">No reviews yet</span>
-      </div>
-    )
-  }
-
-  return (
-    <div className="flex h-4 w-full items-stretch overflow-hidden rounded-full bg-zinc-800">
-      {segments.map(segment => {
-        const percent = Math.round((segment.value / total) * 100)
-        const segmentClasses = [
-          segment.color,
-          'h-full w-full transition-[filter] duration-150 ease-out',
-          'group-hover:brightness-110 group-focus-visible:brightness-110',
-        ].join(' ')
-
-        const tooltipClasses = [
-          'pointer-events-none absolute bottom-full left-1/2 mb-2 -translate-x-1/2 translate-y-1',
-          'whitespace-nowrap rounded bg-zinc-900 px-2 py-1 text-xs text-zinc-100 opacity-0 shadow-lg transition',
-          'group-hover:translate-y-0 group-hover:opacity-100 group-focus-visible:translate-y-0 group-focus-visible:opacity-100',
-        ].join(' ')
-
-        return (
-          <div
-            key={segment.key}
-            className="relative group flex-1 outline-none"
-            style={{ flexGrow: Math.max(segment.value, 0.0001), flexBasis: 0 }}
-            tabIndex={0}
-            aria-label={`${segment.label}: ${segment.value} (${percent}%)`}
-          >
-            <div className={segmentClasses} />
-            <span className={tooltipClasses}>
-              {segment.label}: {segment.value} ({percent}%)
-            </span>
-          </div>
-        )
-      })}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- replace the separate approval/change/comment columns with a single stacked review mix bar
- add a reusable ReviewBar component that renders proportional colored segments with hover tooltips
- handle zero-review cases gracefully and show approval percentage as "—" when unavailable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5d42fc768832886f1d4e23dd833b8