### PR TITLE
Add stale PR metrics and repo coverage to org stats cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Lightweight dashboard to keep an eye on pull requests across your favorite org r
 
 ## Configure access
 
-1. Copy `server/.env.example` to `server/.env` and tweak values if needed (org slug, ports, limits).
+1. Copy `server/.env.example` to `server/.env` and tweak values if needed (org slug, ports, stale window, limits).
+   * Set `STALE_PR_WINDOW_DAYS` to control how many days without updates qualifies an open PR as stale in the org overview (defaults to 14).
 2. Log in with the GitHub CLI so the server can query data:
    ```bash
    gh auth status

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -128,9 +128,9 @@ export default function App() {
   return (
     <div className="max-w-7xl mx-auto p-4 md:p-8 space-y-8">
       <header className="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
-        <div class="flex items-center gap-4">
-          <img src="./logo.svg" alt="GitHub Dashboard" class="w-14 h-14 rounded-full border border-zinc-700"/>
-          <div class="flex-1 min-w-0">
+        <div className="flex items-center gap-4">
+          <img src="./logo.svg" alt="GitHub Dashboard" className="w-14 h-14 rounded-full border border-zinc-700" />
+          <div className="flex-1 min-w-0">
             <h1 className="text-2xl font-bold">GitHub Dashboard</h1>
             <p className="text-zinc-400 text-sm">Monitor organization health, pull requests, and reviews in one place.</p>
           </div>

--- a/client/src/components/OrgStatsView.tsx
+++ b/client/src/components/OrgStatsView.tsx
@@ -73,7 +73,7 @@ function UserHighlight({
       emptyMessage={`No user activity in the last ${windowLabel}.`}
       footer={
         secondary.length ? (
-          <ol className="mt-3 space-y-2 pt-3 border-t border-zinc-800">
+          <ol className="space-y-2 border-t border-zinc-800">
             {secondary.map((user) => (
               <li key={user.login} className="flex items-center gap-3 justify-between">
                 <div className="flex items-center gap-3 min-w-0">
@@ -151,7 +151,7 @@ function RepoHighlight({
       emptyMessage={`No repository activity in the last ${windowLabel}.`}
       footer={
         secondary.length ? (
-          <ol className="mt-3 space-y-2 pt-3 border-t border-zinc-800 text-sm text-zinc-400">
+          <ol className="space-y-2 border-t border-zinc-800 text-sm text-zinc-400">
             {secondary.map((repo) => (
               <li key={repo.nameWithOwner} className="flex items-center justify-between gap-3">
                 <a

--- a/client/src/components/OrgStatsView.tsx
+++ b/client/src/components/OrgStatsView.tsx
@@ -210,7 +210,10 @@ export default function OrgStatsView({ org, windowSel, onChangeSelected }: Props
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
         <div className="card p-5 flex flex-col gap-2">
           <span className="text-xs uppercase tracking-wide text-zinc-400">PRs currently open</span>
-          <span className="text-4xl font-semibold text-zinc-100">{formatCount(totals.openPRs)}</span>
+          <div className="flex items-baseline gap-3">
+            <span className="text-4xl font-semibold text-zinc-100">{formatCount(totals.openPRs)}</span>
+            <span className="text-sm text-zinc-500">Stale: {formatCount(totals.stalePRs)}</span>
+          </div>
           <span className="text-xs text-zinc-500">Across the entire organization</span>
         </div>
         <div className="card p-5 flex flex-col gap-4">
@@ -234,12 +237,18 @@ export default function OrgStatsView({ org, windowSel, onChangeSelected }: Props
         </div>
         <div className="card p-5 flex flex-col gap-2">
           <span className="text-xs uppercase tracking-wide text-zinc-400">Commits last {windowLabel}</span>
-          <span className="text-4xl font-semibold text-zinc-100">{formatCount(totals.commits)}</span>
+          <div className="flex items-baseline gap-2">
+            <span className="text-4xl font-semibold text-zinc-100">{formatCount(totals.commits)}</span>
+            <span className="text-sm text-zinc-500">in {formatCount(totals.commitRepos)} repos</span>
+          </div>
           <span className="text-xs text-zinc-500">Committed by org members</span>
         </div>
         <div className="card p-5 flex flex-col gap-2">
           <span className="text-xs uppercase tracking-wide text-zinc-400">Reviews last {windowLabel}</span>
-          <span className="text-4xl font-semibold text-zinc-100">{formatCount(totals.reviews)}</span>
+          <div className="flex items-baseline gap-2">
+            <span className="text-4xl font-semibold text-zinc-100">{formatCount(totals.reviews)}</span>
+            <span className="text-sm text-zinc-500">in {formatCount(totals.reviewRepos)} repos</span>
+          </div>
           <span className="text-xs text-zinc-500">Completed by org members</span>
         </div>
       </div>

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -64,11 +64,14 @@ export type OrgStats = {
   since: string
   totals: {
     openPRs: number
+    stalePRs: number
     prsOpened: number
     prsMerged: number
     prsClosed: number
     commits: number
+    commitRepos: number
     reviews: number
+    reviewRepos: number
   }
   topUsers: {
     reviewer: OrgStatUser[]

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,3 +1,4 @@
 ORG_SLUG=github
 PORT=5174
 GH_BIN=C:\\Program Files\\GitHub CLI\\gh.exe
+STALE_PR_WINDOW_DAYS=14

--- a/server/src/gh.ts
+++ b/server/src/gh.ts
@@ -38,6 +38,12 @@ export async function ghRepos(org: string): Promise<Repo[]> {
 const ghBin = process.env.GH_BIN ?? "gh";
 const PR_LIMIT = Number(process.env.PR_LIMIT ?? 50);      // PRs per repo
 const REPO_BATCH = Number(process.env.REPO_BATCH ?? 8);   // repos per GraphQL query
+const DEFAULT_STALE_PR_WINDOW_DAYS = 14;
+const staleWindowDaysRaw = Number(process.env.STALE_PR_WINDOW_DAYS);
+const STALE_PR_WINDOW_DAYS =
+  Number.isFinite(staleWindowDaysRaw) && staleWindowDaysRaw > 0
+    ? staleWindowDaysRaw
+    : DEFAULT_STALE_PR_WINDOW_DAYS;
 
 function chunk<T>(arr: T[], size: number): T[][] {
   const out: T[][] = [];
@@ -191,6 +197,12 @@ export async function ghPRsAcross(
 
 function buildSinceISO(window: "24h" | "7d" | "30d"): string {
   const ms = { "24h": 24*60*60e3, "7d": 7*24*60*60e3, "30d": 30*24*60*60e3 }[window];
+  return new Date(Date.now() - ms).toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+function buildSinceISOFromDays(days: number): string {
+  const safeDays = Number.isFinite(days) && days > 0 ? days : DEFAULT_STALE_PR_WINDOW_DAYS;
+  const ms = safeDays * 24 * 60 * 60 * 1000;
   return new Date(Date.now() - ms).toISOString().replace(/\.\d{3}Z$/, "Z");
 }
 
@@ -650,7 +662,7 @@ function mapToTopRepos(map: Map<string, number>, limit = 3): OrgStatRepo[] {
 
 export async function ghOrgStats(org: string, window: "24h" | "7d" | "30d"): Promise<OrgStats> {
   const since = buildSinceISO(window);
-  const staleSince = buildSinceISO("7d");
+  const staleSince = buildSinceISOFromDays(STALE_PR_WINDOW_DAYS);
 
   const SEARCH_Q = `
     query($open:String!, $stale:String!, $opened:String!, $merged:String!, $closed:String!) {

--- a/server/src/gh.ts
+++ b/server/src/gh.ts
@@ -650,10 +650,12 @@ function mapToTopRepos(map: Map<string, number>, limit = 3): OrgStatRepo[] {
 
 export async function ghOrgStats(org: string, window: "24h" | "7d" | "30d"): Promise<OrgStats> {
   const since = buildSinceISO(window);
+  const staleSince = buildSinceISO("7d");
 
   const SEARCH_Q = `
-    query($open:String!, $opened:String!, $merged:String!, $closed:String!) {
+    query($open:String!, $stale:String!, $opened:String!, $merged:String!, $closed:String!) {
       open: search(query:$open, type:ISSUE) { issueCount }
+      stale: search(query:$stale, type:ISSUE) { issueCount }
       opened: search(query:$opened, type:ISSUE) { issueCount }
       merged: search(query:$merged, type:ISSUE) { issueCount }
       closed: search(query:$closed, type:ISSUE) { issueCount }
@@ -662,6 +664,7 @@ export async function ghOrgStats(org: string, window: "24h" | "7d" | "30d"): Pro
 
   const searchData = await runGraphQL(SEARCH_Q, {
     open: `org:${org} is:pr is:open`,
+    stale: `org:${org} is:pr is:open updated:<${staleSince}`,
     opened: `org:${org} is:pr created:>=${since}`,
     merged: `org:${org} is:pr is:merged merged:>=${since}`,
     closed: `org:${org} is:pr is:closed -is:merged closed:>=${since}`,
@@ -669,11 +672,14 @@ export async function ghOrgStats(org: string, window: "24h" | "7d" | "30d"): Pro
 
   const totals = {
     openPRs: Number(searchData?.open?.issueCount ?? 0) || 0,
+    stalePRs: Number(searchData?.stale?.issueCount ?? 0) || 0,
     prsOpened: Number(searchData?.opened?.issueCount ?? 0) || 0,
     prsMerged: Number(searchData?.merged?.issueCount ?? 0) || 0,
     prsClosed: Number(searchData?.closed?.issueCount ?? 0) || 0,
     commits: 0,
+    commitRepos: 0,
     reviews: 0,
+    reviewRepos: 0,
   } satisfies OrgStats["totals"];
 
   const orgId = await getOrgId(org);
@@ -780,6 +786,9 @@ export async function ghOrgStats(org: string, window: "24h" | "7d" | "30d"): Pro
   const topReviewers = mapToTopUsers(reviewerStats);
   const topCommitters = mapToTopUsers(committerStats);
   const topPROpeners = mapToTopUsers(prOpenerStats);
+
+  totals.commitRepos = repoCommits.size;
+  totals.reviewRepos = repoReviews.size;
 
   return {
     since,

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -90,11 +90,14 @@ export interface OrgStatRepo {
 
 export interface OrgStatsSummary {
   openPRs: number;
+  stalePRs: number;
   prsOpened: number;
   prsMerged: number;
   prsClosed: number;
   commits: number;
+  commitRepos: number;
   reviews: number;
+  reviewRepos: number;
 }
 
 export interface OrgStats {


### PR DESCRIPTION
## Summary
- include stale open PR counts in the organization overview card and show commit/review repo coverage
- extend org stats API/types to provide stale PR totals plus commit/review repository counts
- fix the app header markup to use React-compatible className attributes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7246e510c8328be433f40d9cf4870