### PR TITLE
Add organization activity feed with filtering

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import ReviewersView from './components/ReviewersView'
 import ReviewersSidebar from './components/ReviewersSidebar'
 import OrgSelectorModal from './components/OrgSelectorModal'
 import OrgStatsView from './components/OrgStatsView'
+import ActivityView from './components/ActivityView'
 import { loadSettings, saveSettings } from './store'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { fetchTeams, fetchViewer, fetchOrgMembers } from './api'
@@ -22,7 +23,7 @@ export default function App() {
   const [org, setOrg] = useState(loadSettings().org)
   const [username, setUsername] = useState(loadSettings().username)
   const [favorites, setFavorites] = useState<string[]>(loadSettings().favorites)
-  const [tab, setTab] = useState<'org'|'prs'|'reviewers'>('org')
+  const [tab, setTab] = useState<'org'|'prs'|'reviewers'|'activity'>('org')
   const [reviewWindow, setReviewWindow] = useState<'24h'|'7d'|'30d'>('24h')
   const [selectedUsers, setSelectedUsers] = useState<string[]>([])
   const [selectedTeams, setSelectedTeams] = useState<string[]>([])
@@ -180,10 +181,13 @@ export default function App() {
             <button onClick={() => setTab('org')} className={`px-3 py-1 text-sm ${tab==='org' ? 'bg-brand-500/20' : ''}`}>Org</button>
             <button onClick={() => setTab('prs')} className={`px-3 py-1 text-sm ${tab==='prs' ? 'bg-brand-500/20' : ''}`}>PRs</button>
             <button onClick={() => setTab('reviewers')} className={`px-3 py-1 text-sm ${tab==='reviewers' ? 'bg-brand-500/20' : ''}`}>Reviews</button>
+            <button onClick={() => setTab('activity')} className={`px-3 py-1 text-sm ${tab==='activity' ? 'bg-brand-500/20' : ''}`}>Activity</button>
           </div>
         </div>
       </header>
-      {tab === 'org' ? (
+      {tab === 'activity' ? (
+        <ActivityView org={org} />
+      ) : tab === 'org' ? (
         <OrgStatsView org={org} windowSel={reviewWindow} onChangeSelected={setReviewWindow} />
       ) : (
         <section className="grid md:grid-cols-3 gap-6">

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import type { Repo, PREnriched, ReviewerStat, OrgTeam, ViewerInfo, OrgMember, OrgStats } from './types'
+import type { Repo, PREnriched, ReviewerStat, OrgTeam, ViewerInfo, OrgMember, OrgStats, ActivityResponse, ActivityRequest } from './types'
 
 export async function fetchRepos(org: string): Promise<Repo[]> {
   const { data } = await axios.get<{ repos: Repo[] }>(`/api/orgs/${encodeURIComponent(org)}/repos`)
@@ -48,4 +48,20 @@ export async function fetchOrgMembers(org: string): Promise<OrgMember[]> {
 export async function fetchOrgStats(org: string, window: '24h'|'7d'|'30d'): Promise<OrgStats> {
   const { data } = await axios.post<{ stats: OrgStats }>(`/api/orgs/${encodeURIComponent(org)}/stats`, { window })
   return data.stats
+}
+
+export async function fetchActivity(org: string, params: ActivityRequest): Promise<ActivityResponse> {
+  const payload: Record<string, unknown> = {}
+  if (params.types?.length) payload.types = params.types
+  const repo = params.repo?.trim()
+  if (repo) payload.repo = repo
+  const username = params.username?.trim()
+  if (username) payload.username = username
+  const fullname = params.fullname?.trim()
+  if (fullname) payload.fullname = fullname
+  if (params.cursor) payload.cursor = params.cursor
+  if (params.pageSize) payload.pageSize = params.pageSize
+
+  const { data } = await axios.post<ActivityResponse>(`/api/orgs/${encodeURIComponent(org)}/activity`, payload)
+  return data
 }

--- a/client/src/components/ActivityView.tsx
+++ b/client/src/components/ActivityView.tsx
@@ -1,0 +1,347 @@
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { fetchActivity } from '../api'
+import type { ActivityItem, ActivityType, ActivityResponse } from '../types'
+import { fromNow, short } from '../lib_time'
+
+const TYPE_LABEL: Record<ActivityType, string> = {
+  commit: 'Commit',
+  review: 'Review',
+  merge: 'Merge',
+}
+
+const TYPE_BADGE_CLASS: Record<ActivityType, string> = {
+  commit: 'bg-blue-500/10 text-blue-200 border border-blue-500/30',
+  review: 'bg-emerald-500/10 text-emerald-200 border border-emerald-500/30',
+  merge: 'bg-purple-500/10 text-purple-200 border border-purple-500/30',
+}
+
+const TYPE_OPTIONS: ActivityType[] = ['commit', 'review', 'merge']
+
+const PAGE_SIZE = 20
+
+type ActivityViewProps = {
+  org?: string | null
+}
+
+function useDebouncedValue<T>(value: T, delay: number) {
+  const [debounced, setDebounced] = useState(value)
+
+  useEffect(() => {
+    const handle = setTimeout(() => setDebounced(value), delay)
+    return () => clearTimeout(handle)
+  }, [value, delay])
+
+  return debounced
+}
+
+function ActivitySummary({ item }: { item: ActivityItem }) {
+  if (item.type === 'commit') {
+    const { commitCount, branch, message, url } = item.data
+    return (
+      <div className="space-y-1 text-sm text-zinc-200">
+        <p>
+          <span className="font-semibold">{commitCount}</span>{' '}
+          commit{commitCount === 1 ? '' : 's'} pushed
+          {branch ? (
+            <>
+              {' '}to <span className="font-mono text-blue-200">{branch}</span>
+            </>
+          ) : null}
+          .
+        </p>
+        {message ? (
+          <p className="text-xs text-zinc-400 truncate" title={message}>
+            “{message}”
+          </p>
+        ) : null}
+        {url ? (
+          <p>
+            <a
+              href={url}
+              target="_blank"
+              rel="noreferrer"
+              className="text-xs text-blue-300 hover:text-blue-200"
+            >
+              View latest commit →
+            </a>
+          </p>
+        ) : null}
+      </div>
+    )
+  }
+
+  if (item.type === 'review') {
+    const { state, prNumber, prTitle, prUrl, author } = item.data
+    const stateLabel = state.toLowerCase().replace(/_/g, ' ')
+    return (
+      <div className="space-y-1 text-sm text-zinc-200">
+        <p>
+          Reviewed{' '}
+          <a
+            href={prUrl ?? '#'}
+            target={prUrl ? '_blank' : undefined}
+            rel={prUrl ? 'noreferrer' : undefined}
+            className={prUrl ? 'text-emerald-300 hover:text-emerald-200' : 'text-zinc-200'}
+          >
+            PR #{prNumber}
+          </a>{' '}
+          {prTitle ? `“${prTitle}”` : ''} with a
+          {' '}
+          <span className="font-semibold uppercase tracking-wide text-xs text-emerald-200">
+            {stateLabel}
+          </span>{' '}
+          review.
+        </p>
+        {author?.login ? (
+          <p className="text-xs text-zinc-400">
+            Requested by{' '}
+            <span className="font-semibold text-zinc-300">{author.login}</span>
+            {author.name && author.name !== author.login ? ` (${author.name})` : ''}
+          </p>
+        ) : null}
+      </div>
+    )
+  }
+
+  const { prNumber, prTitle, prUrl, author, mergedBy } = item.data
+  return (
+    <div className="space-y-1 text-sm text-zinc-200">
+      <p>
+        Merged{' '}
+        <a
+          href={prUrl ?? '#'}
+          target={prUrl ? '_blank' : undefined}
+          rel={prUrl ? 'noreferrer' : undefined}
+          className={prUrl ? 'text-purple-300 hover:text-purple-200' : 'text-zinc-200'}
+        >
+          PR #{prNumber}
+        </a>{' '}
+        {prTitle ? `“${prTitle}”` : ''}.
+      </p>
+      {author?.login ? (
+        <p className="text-xs text-zinc-400">
+          Authored by{' '}
+          <span className="font-semibold text-zinc-300">{author.login}</span>
+          {author.name && author.name !== author.login ? ` (${author.name})` : ''}
+        </p>
+      ) : null}
+      {mergedBy?.login && mergedBy.login !== item.actor.login ? (
+        <p className="text-xs text-zinc-400">
+          Merge completed by{' '}
+          <span className="font-semibold text-zinc-300">{mergedBy.login}</span>
+          {mergedBy.name && mergedBy.name !== mergedBy.login ? ` (${mergedBy.name})` : ''}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+export default function ActivityView({ org }: ActivityViewProps) {
+  const [selectedTypes, setSelectedTypes] = useState<ActivityType[]>([])
+  const [repoInput, setRepoInput] = useState('')
+  const [usernameInput, setUsernameInput] = useState('')
+  const [fullnameInput, setFullnameInput] = useState('')
+
+  const debouncedRepo = useDebouncedValue(repoInput, 300)
+  const debouncedUsername = useDebouncedValue(usernameInput, 300)
+  const debouncedFullname = useDebouncedValue(fullnameInput, 300)
+
+  const filters = useMemo(() => ({
+    types: selectedTypes.length ? selectedTypes : undefined,
+    repo: debouncedRepo.trim() ? debouncedRepo.trim() : undefined,
+    username: debouncedUsername.trim() ? debouncedUsername.trim() : undefined,
+    fullname: debouncedFullname.trim() ? debouncedFullname.trim() : undefined,
+  }), [selectedTypes, debouncedRepo, debouncedUsername, debouncedFullname])
+
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery<ActivityResponse, Error>({
+    queryKey: ['activity', org, filters],
+    enabled: !!org,
+    initialPageParam: undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    queryFn: ({ pageParam }) =>
+      fetchActivity(org!, {
+        ...filters,
+        cursor: typeof pageParam === 'string' ? pageParam : undefined,
+        pageSize: PAGE_SIZE,
+      }),
+  })
+
+  useEffect(() => {
+    if (!data?.pages?.length) return
+    const last = data.pages[data.pages.length - 1]
+    if (last && last.items.length === 0 && last.nextCursor && !isFetchingNextPage) {
+      fetchNextPage()
+    }
+  }, [data, fetchNextPage, isFetchingNextPage])
+
+  const observerRef = useRef<HTMLDivElement | null>(null)
+  useEffect(() => {
+    if (!hasNextPage) return
+    const target = observerRef.current
+    if (!target) return
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0]?.isIntersecting) {
+        fetchNextPage()
+      }
+    }, { rootMargin: '200px' })
+
+    observer.observe(target)
+    return () => observer.disconnect()
+  }, [fetchNextPage, hasNextPage])
+
+  const items: ActivityItem[] = data?.pages?.flatMap((page) => page.items) ?? []
+
+  const toggleType = (type: ActivityType) => {
+    setSelectedTypes((prev) =>
+      prev.includes(type) ? prev.filter((t) => t !== type) : [...prev, type]
+    )
+  }
+
+  if (!org) {
+    return <div className="card p-6 text-sm text-zinc-400">Choose an organization to view recent activity.</div>
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="card p-4 space-y-4">
+        <div>
+          <h2 className="text-lg font-semibold text-zinc-100">Recent activity</h2>
+          <p className="text-sm text-zinc-400">Monitor commits, reviews, and merges across the organization.</p>
+        </div>
+        <div className="flex flex-wrap gap-4">
+          <div>
+            <p className="text-xs uppercase text-zinc-500 tracking-wide mb-1">Activity types</p>
+            <div className="flex flex-wrap gap-2">
+              {TYPE_OPTIONS.map((type) => {
+                const active = selectedTypes.includes(type)
+                return (
+                  <button
+                    key={type}
+                    onClick={() => toggleType(type)}
+                    className={`px-3 py-1 rounded-full border transition ${
+                      active
+                        ? TYPE_BADGE_CLASS[type]
+                        : 'border-zinc-700 text-zinc-300 hover:bg-zinc-800'
+                    }`}
+                  >
+                    {TYPE_LABEL[type]}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+          <div className="flex flex-col">
+            <label className="text-xs uppercase text-zinc-500 tracking-wide mb-1">Repository</label>
+            <input
+              value={repoInput}
+              onChange={(e) => setRepoInput(e.target.value)}
+              placeholder="e.g. org/repo"
+              className="bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:ring-1 focus:ring-brand-500"
+            />
+          </div>
+          <div className="flex flex-col">
+            <label className="text-xs uppercase text-zinc-500 tracking-wide mb-1">Username</label>
+            <input
+              value={usernameInput}
+              onChange={(e) => setUsernameInput(e.target.value)}
+              placeholder="login"
+              className="bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:ring-1 focus:ring-brand-500"
+            />
+          </div>
+          <div className="flex flex-col">
+            <label className="text-xs uppercase text-zinc-500 tracking-wide mb-1">Full name</label>
+            <input
+              value={fullnameInput}
+              onChange={(e) => setFullnameInput(e.target.value)}
+              placeholder="Name"
+              className="bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:ring-1 focus:ring-brand-500"
+            />
+          </div>
+        </div>
+      </div>
+
+      {isError ? (
+        <div className="card p-6 text-sm text-red-300">
+          <p>Unable to load activity.</p>
+          <p className="text-xs text-red-400/80 mt-2">
+            {error instanceof Error ? error.message : 'Unknown error'}
+          </p>
+        </div>
+      ) : null}
+
+      <div className="space-y-3">
+        {items.map((item) => (
+          <article
+            key={`${item.type}-${item.id}-${item.occurredAt}`}
+            className="card p-4 flex gap-4 items-start"
+          >
+            {item.actor.avatarUrl ? (
+              <img
+                src={item.actor.avatarUrl}
+                alt={`${item.actor.login} avatar`}
+                className="w-12 h-12 rounded-full border border-zinc-700"
+              />
+            ) : (
+              <div className="w-12 h-12 rounded-full bg-zinc-800 border border-zinc-700 flex items-center justify-center text-sm uppercase text-zinc-300">
+                {item.actor.login.slice(0, 2)}
+              </div>
+            )}
+            <div className="flex-1 space-y-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <div className="flex items-center gap-2">
+                  <span className="font-semibold text-zinc-100">{item.actor.login}</span>
+                  {item.actor.name && item.actor.name !== item.actor.login ? (
+                    <span className="text-xs text-zinc-400">{item.actor.name}</span>
+                  ) : null}
+                </div>
+                <span className={`text-xs px-2 py-0.5 rounded-full ${TYPE_BADGE_CLASS[item.type]}`}>
+                  {TYPE_LABEL[item.type]}
+                </span>
+                <span className="ml-auto text-xs text-zinc-500">
+                  {fromNow(item.occurredAt)} · {short(item.occurredAt)}
+                </span>
+              </div>
+              <ActivitySummary item={item} />
+              <div className="flex flex-wrap items-center gap-2 text-xs text-zinc-400">
+                <span className="px-2 py-1 bg-zinc-900 border border-zinc-700 rounded-full font-mono text-[11px]">
+                  {item.repo}
+                </span>
+                {item.type === 'commit' && item.data.branch ? (
+                  <span className="px-2 py-1 bg-blue-500/10 border border-blue-500/30 text-blue-200 rounded-full text-[11px] font-mono">
+                    {item.data.branch}
+                  </span>
+                ) : null}
+              </div>
+            </div>
+          </article>
+        ))}
+
+        {isLoading ? (
+          <div className="card p-6 text-sm text-zinc-400">Loading activity…</div>
+        ) : null}
+
+        {!isLoading && items.length === 0 ? (
+          <div className="card p-6 text-sm text-zinc-400">No activity matched the selected filters.</div>
+        ) : null}
+
+        {hasNextPage ? (
+          <div ref={observerRef} className="h-1" />
+        ) : null}
+
+        {isFetchingNextPage ? (
+          <div className="card p-4 text-xs text-zinc-400">Loading more activity…</div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -84,3 +84,57 @@ export type OrgStats = {
     prsOpened: OrgStatRepo[]
   }
 }
+
+export type ActivityType = 'commit' | 'review' | 'merge'
+
+export type ActivityUser = {
+  login: string
+  name?: string | null
+  avatarUrl?: string | null
+}
+
+export type ActivityCommitData = {
+  type: 'commit'
+  branch?: string | null
+  commitCount: number
+  message?: string | null
+  sha?: string | null
+  url?: string | null
+}
+
+export type ActivityReviewData = {
+  type: 'review'
+  state: string
+  prNumber: number
+  prTitle?: string | null
+  prUrl?: string | null
+  author?: ActivityUser | null
+}
+
+export type ActivityMergeData = {
+  type: 'merge'
+  prNumber: number
+  prTitle?: string | null
+  prUrl?: string | null
+  author?: ActivityUser | null
+  mergedBy?: ActivityUser | null
+}
+
+export type ActivityItem =
+  | { id: string; type: 'commit'; occurredAt: string; repo: string; actor: ActivityUser; data: ActivityCommitData }
+  | { id: string; type: 'review'; occurredAt: string; repo: string; actor: ActivityUser; data: ActivityReviewData }
+  | { id: string; type: 'merge'; occurredAt: string; repo: string; actor: ActivityUser; data: ActivityMergeData }
+
+export type ActivityResponse = {
+  items: ActivityItem[]
+  nextCursor?: string | null
+}
+
+export type ActivityRequest = {
+  types?: ActivityType[]
+  repo?: string
+  username?: string
+  fullname?: string
+  cursor?: string | null
+  pageSize?: number
+}

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -85,7 +85,7 @@ export type OrgStats = {
   }
 }
 
-export type ActivityType = 'commit' | 'review' | 'merge'
+export type ActivityType = 'pr_opened' | 'pr_closed' | 'pr_merged' | 'review'
 
 export type ActivityUser = {
   login: string
@@ -93,13 +93,21 @@ export type ActivityUser = {
   avatarUrl?: string | null
 }
 
-export type ActivityCommitData = {
-  type: 'commit'
-  branch?: string | null
-  commitCount: number
-  message?: string | null
-  sha?: string | null
-  url?: string | null
+export type ActivityPROpenedData = {
+  type: 'pr_opened'
+  prNumber: number
+  prTitle?: string | null
+  prUrl?: string | null
+  author?: ActivityUser | null
+}
+
+export type ActivityPRClosedData = {
+  type: 'pr_closed'
+  prNumber: number
+  prTitle?: string | null
+  prUrl?: string | null
+  author?: ActivityUser | null
+  closedBy?: ActivityUser | null
 }
 
 export type ActivityReviewData = {
@@ -111,19 +119,21 @@ export type ActivityReviewData = {
   author?: ActivityUser | null
 }
 
-export type ActivityMergeData = {
-  type: 'merge'
+export type ActivityPRMergedData = {
+  type: 'pr_merged'
   prNumber: number
   prTitle?: string | null
   prUrl?: string | null
   author?: ActivityUser | null
   mergedBy?: ActivityUser | null
+  commitCount?: number | null
 }
 
 export type ActivityItem =
-  | { id: string; type: 'commit'; occurredAt: string; repo: string; actor: ActivityUser; data: ActivityCommitData }
   | { id: string; type: 'review'; occurredAt: string; repo: string; actor: ActivityUser; data: ActivityReviewData }
-  | { id: string; type: 'merge'; occurredAt: string; repo: string; actor: ActivityUser; data: ActivityMergeData }
+  | { id: string; type: 'pr_opened'; occurredAt: string; repo: string; actor: ActivityUser; data: ActivityPROpenedData }
+  | { id: string; type: 'pr_closed'; occurredAt: string; repo: string; actor: ActivityUser; data: ActivityPRClosedData }
+  | { id: string; type: 'pr_merged'; occurredAt: string; repo: string; actor: ActivityUser; data: ActivityPRMergedData }
 
 export type ActivityResponse = {
   items: ActivityItem[]

--- a/server/src/gh.ts
+++ b/server/src/gh.ts
@@ -461,7 +461,7 @@ export async function ghOrgActivity(org: string, options: ActivityFetchOptions =
     vars.commitFirst = String(commitFirst);
 
     query += `
-      commits: search(query: $commitQuery, type: COMMIT, first: $commitFirst) {
+      commits: search(query: $commitQuery, type: COMMITS, first: $commitFirst) {
         nodes {
           ... on Commit {
             oid

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -131,7 +131,7 @@ app.post("/api/orgs/:org/stats", async (req, res) => {
 
 
 const ActivityBody = z.object({
-  types: z.array(z.enum(["commit", "review", "merge"])).optional(),
+  types: z.array(z.enum(["pr_opened", "pr_closed", "pr_merged", "review"])).optional(),
   repo: z.string().min(1).optional(),
   username: z.string().min(1).optional(),
   fullname: z.string().min(1).optional(),

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,7 +2,7 @@ import express from "express";
 import cors from "cors";
 import dotenv from "dotenv";
 import { z } from "zod";
-import { ghRepos, ghPRsAcross, ghTopReviewers, ghOrgTeams, ghViewerInfo, ghOrgMembers, ghOrgStats } from "./gh.js";
+import { ghRepos, ghPRsAcross, ghTopReviewers, ghOrgTeams, ghViewerInfo, ghOrgMembers, ghOrgStats, ghOrgActivity } from "./gh.js";
 
 
 dotenv.config();
@@ -120,6 +120,39 @@ app.post("/api/orgs/:org/stats", async (req, res) => {
     const body = OrgStatsBody.parse(req.body ?? {});
     const stats = await ghOrgStats(org, body.window);
     res.json({ stats });
+  } catch (e: any) {
+    const msg = `${e?.stderr ?? ""} ${e?.message ?? ""}`;
+    if (/rate limit|abuse/i.test(msg) || e?.exitCode === 403) {
+      return res.status(429).json({ error: "GitHub rate limit", retryAfterMs: 60000 });
+    }
+    res.status(400).json({ error: (e as Error).message });
+  }
+});
+
+
+const ActivityBody = z.object({
+  types: z.array(z.enum(["commit", "review", "merge"])).optional(),
+  repo: z.string().min(1).optional(),
+  username: z.string().min(1).optional(),
+  fullname: z.string().min(1).optional(),
+  cursor: z.string().optional(),
+  pageSize: z.number().int().min(5).max(50).optional(),
+});
+
+app.post("/api/orgs/:org/activity", async (req, res) => {
+  try {
+    const org = z.string().min(1).parse(req.params.org);
+    const body = ActivityBody.parse(req.body ?? {});
+    const page = body.cursor ? Number(body.cursor) : 1;
+    const { items, nextCursor } = await ghOrgActivity(org, {
+      page: Number.isFinite(page) && page > 0 ? page : 1,
+      perPage: body.pageSize,
+      types: body.types ?? null,
+      repo: body.repo ?? null,
+      username: body.username ?? null,
+      fullname: body.fullname ?? null,
+    });
+    res.json({ items, nextCursor });
   } catch (e: any) {
     const msg = `${e?.stderr ?? ""} ${e?.message ?? ""}`;
     if (/rate limit|abuse/i.test(msg) || e?.exitCode === 403) {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -115,7 +115,7 @@ export interface OrgStats {
   };
 }
 
-export type ActivityType = "commit" | "review" | "merge";
+export type ActivityType = "pr_opened" | "pr_closed" | "pr_merged" | "review";
 
 export interface ActivityUser {
   login: string;
@@ -123,13 +123,21 @@ export interface ActivityUser {
   avatarUrl?: string | null;
 }
 
-export interface ActivityCommitData {
-  type: "commit";
-  branch?: string | null;
-  commitCount: number;
-  message?: string | null;
-  sha?: string | null;
-  url?: string | null;
+export interface ActivityPROpenedData {
+  type: "pr_opened";
+  prNumber: number;
+  prTitle?: string | null;
+  prUrl?: string | null;
+  author?: ActivityUser | null;
+}
+
+export interface ActivityPRClosedData {
+  type: "pr_closed";
+  prNumber: number;
+  prTitle?: string | null;
+  prUrl?: string | null;
+  author?: ActivityUser | null;
+  closedBy?: ActivityUser | null;
 }
 
 export interface ActivityReviewData {
@@ -141,24 +149,17 @@ export interface ActivityReviewData {
   author?: ActivityUser | null;
 }
 
-export interface ActivityMergeData {
-  type: "merge";
+export interface ActivityPRMergedData {
+  type: "pr_merged";
   prNumber: number;
   prTitle?: string | null;
   prUrl?: string | null;
   author?: ActivityUser | null;
   mergedBy?: ActivityUser | null;
+  commitCount?: number | null;
 }
 
 export type ActivityItem =
-  | {
-      id: string;
-      type: "commit";
-      occurredAt: string;
-      repo: string;
-      actor: ActivityUser;
-      data: ActivityCommitData;
-    }
   | {
       id: string;
       type: "review";
@@ -169,11 +170,27 @@ export type ActivityItem =
     }
   | {
       id: string;
-      type: "merge";
+      type: "pr_opened";
       occurredAt: string;
       repo: string;
       actor: ActivityUser;
-      data: ActivityMergeData;
+      data: ActivityPROpenedData;
+    }
+  | {
+      id: string;
+      type: "pr_closed";
+      occurredAt: string;
+      repo: string;
+      actor: ActivityUser;
+      data: ActivityPRClosedData;
+    }
+  | {
+      id: string;
+      type: "pr_merged";
+      occurredAt: string;
+      repo: string;
+      actor: ActivityUser;
+      data: ActivityPRMergedData;
     };
 
 export interface ActivityResponse {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -114,3 +114,69 @@ export interface OrgStats {
     prsOpened: OrgStatRepo[];
   };
 }
+
+export type ActivityType = "commit" | "review" | "merge";
+
+export interface ActivityUser {
+  login: string;
+  name?: string | null;
+  avatarUrl?: string | null;
+}
+
+export interface ActivityCommitData {
+  type: "commit";
+  branch?: string | null;
+  commitCount: number;
+  message?: string | null;
+  sha?: string | null;
+  url?: string | null;
+}
+
+export interface ActivityReviewData {
+  type: "review";
+  state: string;
+  prNumber: number;
+  prTitle?: string | null;
+  prUrl?: string | null;
+  author?: ActivityUser | null;
+}
+
+export interface ActivityMergeData {
+  type: "merge";
+  prNumber: number;
+  prTitle?: string | null;
+  prUrl?: string | null;
+  author?: ActivityUser | null;
+  mergedBy?: ActivityUser | null;
+}
+
+export type ActivityItem =
+  | {
+      id: string;
+      type: "commit";
+      occurredAt: string;
+      repo: string;
+      actor: ActivityUser;
+      data: ActivityCommitData;
+    }
+  | {
+      id: string;
+      type: "review";
+      occurredAt: string;
+      repo: string;
+      actor: ActivityUser;
+      data: ActivityReviewData;
+    }
+  | {
+      id: string;
+      type: "merge";
+      occurredAt: string;
+      repo: string;
+      actor: ActivityUser;
+      data: ActivityMergeData;
+    };
+
+export interface ActivityResponse {
+  items: ActivityItem[];
+  nextCursor: string | null;
+}


### PR DESCRIPTION
## Summary
- add a new Activity tab that surfaces commits, reviews, and merges with filtering controls and infinite scrolling
- expose a client API, types, and UI wiring to request organization activity with repo, user, and activity-type filters
- implement a server endpoint backed by GitHub org events, including enrichment and filtering before returning paginated results

## Testing
- npm --prefix server run build
- npm --prefix client run build

------
https://chatgpt.com/codex/tasks/task_e_68db0b83fc94832892c48ec037f2b5fa